### PR TITLE
check travis on changing branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 Successfully tested phpunit with Sum.php, SumTest.php.
 Now changed a little bit.
+
+-------------------------------
+just git checkout khoa to switch branch from master to khoa. now gonna test if travis can be triggered by any changes of branch.
+------------------------------------------------------------


### PR DESCRIPTION
On khoa branch, he has updated REAdME.md  to trigger #6 build on Travis. Now he switched back. the following is text of README.md at #7 build.

"created a branch called khoa and set --upstream orgin khoa, it triggered the travis on branch khoa, but the text on README.md automatically reverted back. Now checkout back to master and test if this README.md file can be updated to repository."